### PR TITLE
Add git safe.directory config for /module

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -78,4 +78,8 @@ ADD docs-config.yml /docs-config.yml
 # and will fail unless we make sure it exists and can be written by all users.
 RUN mkdir /module && chmod 777 /module
 
+# Newer versions of git are strict about directory ownership.
+# Since repos are mounted at /module with different ownership, allow it.
+RUN git config --global --add safe.directory /module
+
 WORKDIR /module


### PR DESCRIPTION
Newer versions of setuptools (vcs_versioning) perform git introspection during pip install, which fails because the mounted repo at /module has different ownership than the container user. This matches the fix already present in docker-builder.